### PR TITLE
Use 'repo_init' and 'clone' to initialize unexisting submodule repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,21 +6,21 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.61-buster
+      image: rust:1.69-buster
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install toolchains
         run: |
-          rustup component add rustfmt --toolchain 1.61.0-x86_64-unknown-linux-gnu
-          rustup component add clippy --toolchain 1.61.0-x86_64-unknown-linux-gnu
+          rustup component add rustfmt --toolchain 1.69.0-x86_64-unknown-linux-gnu
+          rustup component add clippy --toolchain 1.69.0-x86_64-unknown-linux-gnu
           cargo fmt -- --check
           RUSTFLAGS="-D warnings" cargo clippy
           RUSTFLAGS="-D warnings" cargo test -- --nocapture
   build:
     runs-on: ubuntu-latest
     container:
-      image: rust:1.61-buster
+      image: rust:1.69-buster
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: "rust:1.61-buster"
+image: "rust:1.69-buster"
 
 stages:
   - lintertest
@@ -17,8 +17,8 @@ before_script:
 clippy:
   stage: lintertest
   script:
-    - rustup component add rustfmt --toolchain 1.61.0-x86_64-unknown-linux-gnu
-    - rustup component add clippy --toolchain 1.61.0-x86_64-unknown-linux-gnu
+    - rustup component add rustfmt --toolchain 1.69.0-x86_64-unknown-linux-gnu
+    - rustup component add clippy --toolchain 1.69.0-x86_64-unknown-linux-gnu
     - cargo fmt -- --check
     - RUSTFLAGS="-D warnings" cargo clippy
     - RUSTFLAGS="-D warnings" cargo test -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,8 +127,8 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.16.0"
-source = "git+https://github.com/Hyask/git2-rs?branch=master#f587915c99faaeb93d2e5e6e417ad6d6b6792466"
+version = "0.16.1"
+source = "git+https://github.com/rust-lang/git2-rs?branch=master#c5765efabe7dfe5758f875d136ecbf77133d3c95"
 dependencies = [
  "bitflags",
  "libc",
@@ -204,8 +204,8 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.1+1.5.0"
-source = "git+https://github.com/Hyask/git2-rs?branch=master#f587915c99faaeb93d2e5e6e417ad6d6b6792466"
+version = "0.14.2+1.5.1"
+source = "git+https://github.com/rust-lang/git2-rs?branch=master#c5765efabe7dfe5758f875d136ecbf77133d3c95"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,8 +127,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.16.1"
-source = "git+https://github.com/rust-lang/git2-rs?branch=master#c5765efabe7dfe5758f875d136ecbf77133d3c95"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
 dependencies = [
  "bitflags",
  "libc",
@@ -204,8 +205,9 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.2+1.5.1"
-source = "git+https://github.com/rust-lang/git2-rs?branch=master#c5765efabe7dfe5758f875d136ecbf77133d3c95"
+version = "0.15.2+1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
 dependencies = [
  "cc",
  "libc",
@@ -217,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.23"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,8 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+version = "0.16.0"
+source = "git+https://github.com/Hyask/git2-rs?branch=master#f587915c99faaeb93d2e5e6e417ad6d6b6792466"
 dependencies = [
  "bitflags",
  "libc",
@@ -205,9 +204,8 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.4+1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+version = "0.14.1+1.5.0"
+source = "git+https://github.com/Hyask/git2-rs?branch=master#f587915c99faaeb93d2e5e6e417ad6d6b6792466"
 dependencies = [
  "cc",
  "libc",
@@ -294,9 +292,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.22.0+1.1.1q"
+version = "111.24.0+1.1.1s"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.58"
 clap = { version = "3.2.6", features = ["derive"] }
-git2 = { version = "0.14.4", features = ["vendored-libgit2", "vendored-openssl"] }
+# git2 = { version = "0.14.4", features = ["vendored-libgit2", "vendored-openssl"] }
+# TODO reset this to something like the line above when https://github.com/rust-lang/git2-rs/pull/914 will be merged
+git2 = { git = "https://github.com/Hyask/git2-rs", branch = "master", features = ["vendored-libgit2", "vendored-openssl"] }
 owo-colors = "3.4.0"
 serde = { version = "1.0.137", features = ["derive"] }
 tokio = { version = "1.19.2", features = ["rt-multi-thread", "process", "macros", "sync", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.58"
 clap = { version = "3.2.6", features = ["derive"] }
 # git2 = { version = "0.14.4", features = ["vendored-libgit2", "vendored-openssl"] }
 # TODO reset this to something like the line above when https://github.com/rust-lang/git2-rs/pull/914 will be merged
-git2 = { git = "https://github.com/Hyask/git2-rs", branch = "master", features = ["vendored-libgit2", "vendored-openssl"] }
+git2 = { git = "https://github.com/rust-lang/git2-rs", branch = "master", features = ["vendored-libgit2", "vendored-openssl"] }
 owo-colors = "3.4.0"
 serde = { version = "1.0.137", features = ["derive"] }
 tokio = { version = "1.19.2", features = ["rt-multi-thread", "process", "macros", "sync", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.58"
 clap = { version = "3.2.6", features = ["derive"] }
-# git2 = { version = "0.14.4", features = ["vendored-libgit2", "vendored-openssl"] }
-# TODO reset this to something like the line above when https://github.com/rust-lang/git2-rs/pull/914 will be merged
-git2 = { git = "https://github.com/rust-lang/git2-rs", branch = "master", features = ["vendored-libgit2", "vendored-openssl"] }
+git2 = { version = "0.17.2", features = ["vendored-libgit2", "vendored-openssl"] }
 owo-colors = "3.4.0"
 serde = { version = "1.0.137", features = ["derive"] }
 tokio = { version = "1.19.2", features = ["rt-multi-thread", "process", "macros", "sync", "time"] }


### PR DESCRIPTION
Following https://github.com/rust-lang/git2-rs/pull/914, we can now use `repo_init`, which gives us a real repository that we can clone to populate it.

TODO: wait for a tag containing `repo_init` in `git2-rs`, and update our dependency before merge.

Fixes #2 